### PR TITLE
Fix horizontal offset of tooltip for repository links

### DIFF
--- a/src/assets/javascripts/components/tooltip2/index.ts
+++ b/src/assets/javascripts/components/tooltip2/index.ts
@@ -239,8 +239,14 @@ export function mountTooltip2(
       filter(active => active),
       withLatestFrom(node$, viewport$),
       map(([_, node, { size }]) => {
+
+        // Fix horizontal offset of tooltip for repository links
         const host = el.getBoundingClientRect()
-        const x = host.width / 2
+        const originEl = el.querySelector(".md-source__repository") as HTMLElement | null
+        const offsetX = 20
+        const x = originEl
+          ? (originEl.getBoundingClientRect().left - host.left) + (originEl.getBoundingClientRect().width / 2) + offsetX
+          : host.width / 2
 
         // If the tooltip is non-interactive, we always render it below the
         // actual element because all operating systems do it that way


### PR DESCRIPTION
Fixed: Right-offset tooltip for the repo link in the top-right corner of the header (aligned to center)

<img width="757" height="377" alt="iShot_2025-12-12_20 53 56" src="https://github.com/user-attachments/assets/82412c57-2fc1-48be-aacb-d8a79ae4794b" />
