### PR TITLE
chore: upgrade to mono v0.0.5

### DIFF
--- a/.mono.toml
+++ b/.mono.toml
@@ -22,7 +22,7 @@
 # IN THE SOFTWARE.
 
 [changeset.scopes]
-templates = "src"
-scripts = "src/assets/javascripts"
-styles = "src/assets/stylesheets"
-tools = "tools"
+templates = "src/**"
+scripts = "src/assets/javascripts/**"
+styles = "src/assets/stylesheets/**"
+tools = "tools/**"


### PR DESCRIPTION
The way scopes are handled in `.mono.toml` changed, see [v0.0.5] release notes.

[v0.0.5]: https://github.com/zensical/mono/releases/tag/v0.0.5