### PR TITLE
feat: data-driven custom admonitions

### DIFF
--- a/dist/partials/icons.html
+++ b/dist/partials/icons.html
@@ -3,32 +3,36 @@
 -#}
 {% set admonition_icons = config.theme.icon.admonition | d({}, true) %}
 {% set admonition_extra = config.extra.admonitions | d({}, true) %}
-{% set types = [] %}
+{% set ns = namespace(types = []) %}
 {% if admonition_icons is mapping %}
   {% for type, icon in admonition_icons | items %}
-    {% if type and icon and type not in types %}
-      {% set _ = types.append(type) %}
+    {% if type and icon and type not in ns.types %}
+      {% set ns.types = ns.types + [type] %}
     {% endif %}
   {% endfor %}
 {% endif %}
 {% if admonition_extra is mapping %}
   {% for type, data in admonition_extra | items %}
-    {% if type and type not in types %}
+    {% if type and type not in ns.types %}
       {% if data is mapping %}
         {% set has_data = data.icon or data.color %}
       {% else %}
         {% set has_data = data %}
       {% endif %}
       {% if has_data %}
-        {% set _ = types.append(type) %}
+        {% set ns.types = ns.types + [type] %}
       {% endif %}
     {% endif %}
   {% endfor %}
 {% endif %}
-{% if types %}
+{% if ns.types %}
   {% set _ = namespace(style = "\u003cstyle\u003e:root{", has_icon = false) %}
-  {% for type in types %}
-    {% set data = admonition_extra.get(type) if admonition_extra is mapping else None %}
+  {% for type in ns.types %}
+    {% if admonition_extra is mapping and type in admonition_extra %}
+      {% set data = admonition_extra[type] %}
+    {% else %}
+      {% set data = None %}
+    {% endif %}
     {% if data is mapping %}
       {% set icon = data.icon %}
     {% elif data %}
@@ -36,8 +40,8 @@
     {% else %}
       {% set icon = None %}
     {% endif %}
-    {% if not icon and admonition_icons is mapping %}
-      {% set icon = admonition_icons.get(type) %}
+    {% if not icon and admonition_icons is mapping and type in admonition_icons %}
+      {% set icon = admonition_icons[type] %}
     {% endif %}
     {% if icon %}
       {% import ".icons/" ~ icon ~ ".svg" as icon %}
@@ -55,10 +59,14 @@
     {{ _.style }}
   {% endif %}
 {% endif %}
-{% if types %}
+{% if ns.types %}
   <style>
-  {% for type in types %}
-    {% set data = admonition_extra.get(type) if admonition_extra is mapping else None %}
+  {% for type in ns.types %}
+    {% if admonition_extra is mapping and type in admonition_extra %}
+      {% set data = admonition_extra[type] %}
+    {% else %}
+      {% set data = None %}
+    {% endif %}
     {% if data is mapping %}
       {% set color = data.color %}
       {% set icon = data.icon %}
@@ -69,12 +77,20 @@
       {% set color = None %}
       {% set icon = None %}
     {% endif %}
-    {% if not icon and admonition_icons is mapping %}
-      {% set icon = admonition_icons.get(type) %}
+    {% if not icon and admonition_icons is mapping and type in admonition_icons %}
+      {% set icon = admonition_icons[type] %}
     {% endif %}
     {% if color %}
+    {% if config.theme.variant == "modern" %}
     .md-typeset :is(.admonition, details).{{ type }} {
       background-color: color-mix(in srgb, {{ color }} 10%, transparent);
+      border-color: {{ color }};
+    }
+    .md-typeset :is(.admonition, details).{{ type }}:focus-within {
+      box-shadow: 0 0 0 0.25rem color-mix(in srgb, {{ color }} 10%, transparent);
+    }
+    {% else %}
+    .md-typeset :is(.admonition, details).{{ type }} {
       border-color: {{ color }};
     }
     .md-typeset :is(.admonition, details).{{ type }}:focus-within {
@@ -83,6 +99,7 @@
     .md-typeset .{{ type }} > .admonition-title {
       background-color: color-mix(in srgb, {{ color }} 10%, transparent);
     }
+    {% endif %}
     {% endif %}
     {% if color or icon %}
     .md-typeset .{{ type }} > .admonition-title::before {

--- a/src/partials/icons.html
+++ b/src/partials/icons.html
@@ -26,34 +26,38 @@
 {% set admonition_icons = config.theme.icon.admonition | d({}, true) %}
 {% set admonition_extra = config.extra.admonitions | d({}, true) %}
 
-{% set types = [] %}
+{% set ns = namespace(types = []) %}
 {% if admonition_icons is mapping %}
   {% for type, icon in admonition_icons | items %}
-    {% if type and icon and type not in types %}
-      {% set _ = types.append(type) %}
+    {% if type and icon and type not in ns.types %}
+      {% set ns.types = ns.types + [type] %}
     {% endif %}
   {% endfor %}
 {% endif %}
 {% if admonition_extra is mapping %}
   {% for type, data in admonition_extra | items %}
-    {% if type and type not in types %}
+    {% if type and type not in ns.types %}
       {% if data is mapping %}
         {% set has_data = data.icon or data.color %}
       {% else %}
         {% set has_data = data %}
       {% endif %}
       {% if has_data %}
-        {% set _ = types.append(type) %}
+        {% set ns.types = ns.types + [type] %}
       {% endif %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 <!-- Custom admonition icons -->
-{% if types %}
+{% if ns.types %}
   {% set _ = namespace(style = "\u003cstyle\u003e:root{", has_icon = false) %}
-  {% for type in types %}
-    {% set data = admonition_extra.get(type) if admonition_extra is mapping else None %}
+  {% for type in ns.types %}
+    {% if admonition_extra is mapping and type in admonition_extra %}
+      {% set data = admonition_extra[type] %}
+    {% else %}
+      {% set data = None %}
+    {% endif %}
     {% if data is mapping %}
       {% set icon = data.icon %}
     {% elif data %}
@@ -61,8 +65,8 @@
     {% else %}
       {% set icon = None %}
     {% endif %}
-    {% if not icon and admonition_icons is mapping %}
-      {% set icon = admonition_icons.get(type) %}
+    {% if not icon and admonition_icons is mapping and type in admonition_icons %}
+      {% set icon = admonition_icons[type] %}
     {% endif %}
     {% if icon %}
       {% import ".icons/" ~ icon ~ ".svg" as icon %}
@@ -82,10 +86,14 @@
 {% endif %}
 
 <!-- Custom admonition styles -->
-{% if types %}
+{% if ns.types %}
   <style>
-  {% for type in types %}
-    {% set data = admonition_extra.get(type) if admonition_extra is mapping else None %}
+  {% for type in ns.types %}
+    {% if admonition_extra is mapping and type in admonition_extra %}
+      {% set data = admonition_extra[type] %}
+    {% else %}
+      {% set data = None %}
+    {% endif %}
     {% if data is mapping %}
       {% set color = data.color %}
       {% set icon = data.icon %}
@@ -96,12 +104,20 @@
       {% set color = None %}
       {% set icon = None %}
     {% endif %}
-    {% if not icon and admonition_icons is mapping %}
-      {% set icon = admonition_icons.get(type) %}
+    {% if not icon and admonition_icons is mapping and type in admonition_icons %}
+      {% set icon = admonition_icons[type] %}
     {% endif %}
     {% if color %}
+    {% if config.theme.variant == "modern" %}
     .md-typeset :is(.admonition, details).{{ type }} {
       background-color: color-mix(in srgb, {{ color }} 10%, transparent);
+      border-color: {{ color }};
+    }
+    .md-typeset :is(.admonition, details).{{ type }}:focus-within {
+      box-shadow: 0 0 0 0.25rem color-mix(in srgb, {{ color }} 10%, transparent);
+    }
+    {% else %}
+    .md-typeset :is(.admonition, details).{{ type }} {
       border-color: {{ color }};
     }
     .md-typeset :is(.admonition, details).{{ type }}:focus-within {
@@ -110,6 +126,7 @@
     .md-typeset .{{ type }} > .admonition-title {
       background-color: color-mix(in srgb, {{ color }} 10%, transparent);
     }
+    {% endif %}
     {% endif %}
     {% if color or icon %}
     .md-typeset .{{ type }} > .admonition-title::before {


### PR DESCRIPTION
## Approach
This PR makes custom admonitions **data‑driven and open‑ended** in the UI while staying compatible with MiniJinja and existing theme semantics:

### 1) Consume arbitrary admonition types from config
- Read `config.extra.admonitions` for icon/color definitions.
  - Supports both shorthand (`todo = "lucide/list-todo"`) and mapping (`todo = { icon = "…", color = "…" }`).
- Read `config.theme.icon.admonition` (opened up in core PR) for icon‑only overrides.
- Collect all types across both sources and **merge per type**, preferring `extra.admonitions.icon` when present, otherwise falling back to `theme.icon.admonition`.

### 2) Generate CSS for any type (no closed set)
- Emit CSS custom properties for each icon: `--md-admonition-icon--<type>` with inlined SVG data.
- Emit per‑type rules for colors (background/border/title/icon) so a new type works with **only config**.
- Use selectors that work for both regular and collapsible blocks: `:is(.admonition, details).<type>`.

### 3) Make templates MiniJinja‑safe
- Replace `list.append` with `namespace` + list concatenation.
- Replace `dict.get` with `in` checks and direct indexing.

### 4) Match theme variants
- **Modern**: keep body tint + border (matches modern defaults).
- **Classic**: apply only border + title tint (no body tint), matching classic defaults and avoiding the “double layer” look.

### 5) Keep dist artifacts in sync
- Update both `src/partials/icons.html` and `dist/partials/icons.html`.

## Files changed
- `src/partials/icons.html`
- `dist/partials/icons.html`

## Behavior changes
- Any `extra.admonitions.<type>` now produces a styled admonition with icon/color.
- Any `theme.icon.admonition.<type>` now provides icon‑only customization.
- Rendering no longer fails under MiniJinja.
- Classic theme custom colors align with classic built‑ins (no body tint).

## Cross‑repo context
- **Companion core PR (zensical)**: https://github.com/zensical/zensical/pull/265
  - Opens `theme.icon.admonition` as a map and removes fixed defaults.

## Testing
- Built a demo project with custom admonitions (modern + classic variants) and verified:
  - no template errors,
  - icons render for arbitrary types,
  - colors apply as configured,
  - classic visuals match built‑ins.

## Scope notes
- This PR does not add a config‑level title registry. Custom titles still use Markdown syntax (`!!! type "Title"`).

---

<img width="838" height="1033" alt="Screenshot 2026-01-14 at 12 38 22" src="https://github.com/user-attachments/assets/f207de6c-e98f-4b5b-accf-787eef52dcc4" />
<img width="846" height="1043" alt="Screenshot 2026-01-14 at 12 39 57" src="https://github.com/user-attachments/assets/1e9bb8d3-f89f-4bc3-9cf7-8de5985d8b3f" />