### PR TITLE
chore: release v0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Zensical user interface",
   "bugs": {
     "url": "https://github.com/zensical/ui/issues",


### PR DESCRIPTION
## Summary

This version fixes several bugs, including excessive memory usage for pages with hundreds of links that are marked with `data-preview` (for instant previews), and moves the back-to-top button to the bottom in the modern theme.