### PR TITLE
chore: release v0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Zensical user interface",
   "bugs": {
     "url": "https://github.com/zensical/ui/issues",


### PR DESCRIPTION
## Summary

This version fixes two bugs for search, where exiting search on mobile would make the page unscrollable, and where scrolling would chain to the entire page on mobile.