### PR TITLE
chore: release v0.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Zensical user interface",
   "bugs": {
     "url": "https://github.com/zensical/ui/issues",


### PR DESCRIPTION
## Summary

This version includes breaking changes for icons, as Lucide has been updated to v1, which includes the [removal of 19 brand icons]. 166 new icons are added, most of them brand icons in [SimpleIcons] and [FontAwesome]. Additionally, there are bug fixes related to the latest changes of the table of contents in the modern theme and instant navigation on anchor links.

In case you were using any of the removed icons, we recommend switching to the equivalent icon from the SimpleIcons or FontAwesome icon sets.

[removal of 19 brand icons]: https://lucide.dev/guide/version-1
[SimpleIcons]: https://simpleicons.org/
[FontAwesome]: https://fontawesome.com/