### PR TITLE
chore: release v0.0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Zensical user interface",
   "bugs": {
     "url": "https://github.com/zensical/ui/issues",


### PR DESCRIPTION
## Summary

This version adds native support for [GLightbox], a JavaScript lightbox library to add zoom and gallery features to images. If an image is wrapped in a link with the `glightbox` class attached, it will be automatically integrated into an image gallery and become zoomable.

The next version of Zensical, which will be released shortly after, will include a complementary Markdown Extension for automatically wrapping images in the appropriate markup to enable GLightbox features without requiring manual tagging in Markdown files.

### Highlights

- Add support for [GLightbox], a JavaScript lightbox library for zooming and galleries
- Section titles in the table of contents will render with markup from now on

[GLightbox]: https://biati-digital.github.io/glightbox/