### PR TITLE
chore: release v0.0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Zensical user interface",
   "bugs": {
     "url": "https://github.com/zensical/ui/issues",


### PR DESCRIPTION
## Summary

This version adds support for sourcing section titles from Markdown files when the title is left empty in the `nav` setting as defined in the configuration when [`navigation.indexes`][indexes] is enabled.

[indexes]: https://zensical.org/docs/setup/navigation/#section-index-pages