### PR TITLE
fix: escape URLs in sitemap

### DIFF
--- a/dist/sitemap.xml
+++ b/dist/sitemap.xml
@@ -6,7 +6,7 @@
   {%- for page in pages -%}
     {%- if page.canonical_url %}
       <url>
-        <loc>{{ page.canonical_url }}</loc>
+        <loc>{{ page.canonical_url | escape }}</loc>
       </url>
     {%- endif -%}
   {%- endfor %}

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -3,7 +3,7 @@
   {%- for page in pages -%}
     {%- if page.canonical_url %}
       <url>
-        <loc>{{ page.canonical_url }}</loc>
+        <loc>{{ page.canonical_url | escape }}</loc>
       </url>
     {%- endif -%}
   {%- endfor %}


### PR DESCRIPTION
Issue https://github.com/zensical/zensical/issues/772.

Example sitemap after this change:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
      <url>
        <loc>http:&#x2f;&#x2f;localhost:8000&#x2f;</loc>
      </url>
      <url>
        <loc>http:&#x2f;&#x2f;localhost:8000&#x2f;markdown&#x2f;</loc>
      </url>
      <url>
        <loc>http:&#x2f;&#x2f;localhost:8000&#x2f;test&amp;test&#x2f;test&#x2f;</loc>
      </url>
</urlset>
```

This fixes the instant preview in the mentioned issue.