### PR TITLE
fix: fix index URL from where pyodide fetches packages

### DIFF
--- a/src/assets/javascripts/components/content/exec/index.ts
+++ b/src/assets/javascripts/components/content/exec/index.ts
@@ -282,7 +282,7 @@ function initPyodide(): Observable<Promise<PyodideInterface | null>> {
     map(async () => {
       try {
         const pyodide = await loadPyodide({
-          indexURL: "https://unpkg.com/pyodide@314.0.2/",
+          indexURL: "https://cdn.jsdelivr.net/pyodide/v314.0.2/full/",
         });
         await pyodide.loadPackage("micropip");
         return pyodide;


### PR DESCRIPTION
The package registry is only available at JsDelivr, not unpkg.