### PR TITLE
fix: use pyodide session and min-lines/max-lines data attributes

### DIFF
--- a/src/assets/javascripts/components/content/exec/index.ts
+++ b/src/assets/javascripts/components/content/exec/index.ts
@@ -61,6 +61,8 @@ interface Elements {
   source: string;
   session: string;
   install: string[];
+  minLines: number;
+  maxLines: number;
 }
 
 /* ----------------------------------------------------------------------------
@@ -137,20 +139,6 @@ function parsePackages(value: string | undefined): string[] {
 }
 
 /**
- * Extract the configured session name from the canonical scaffold
- *
- * @param el - Pyodide root element
- *
- * @returns Session name
- */
-function getSessionName(el: HTMLElement): string {
-  const label = el.querySelector(".pyodide-editor-bar .pyodide-bar-item");
-  const text = label?.textContent ?? "";
-  const match = text.match(/session:\s*([^)]+)\)?/i);
-  return match?.[1]?.trim() || "default";
-}
-
-/**
  * Extract the canonical scaffold elements
  *
  * @param el - Pyodide root element
@@ -175,8 +163,10 @@ function getElements(el: HTMLElement): Elements {
     run,
     clear,
     source: editor.textContent?.trimEnd() ?? "",
-    session: getSessionName(el),
+    session: el.dataset.session ?? "default",
     install: parsePackages(el.dataset.install),
+    minLines: typeof el.dataset.minLines == "undefined" ? 0 : parseInt(el.dataset.minLines),
+    maxLines: typeof el.dataset.maxLines == "undefined" ? Infinity : parseInt(el.dataset.maxLines),
   };
 }
 
@@ -412,8 +402,8 @@ export function mountPyodide(el: HTMLElement): Observable<Component<Pyodide>> {
       editor.setTheme("ace/theme/zensical");
       editor.session.setMode("ace/mode/python");
       editor.setOption("fontFamily", "var(--md-code-font)");
-      editor.setOption("minLines", 0);
-      editor.setOption("maxLines", Infinity);
+      editor.setOption("minLines", elements.minLines);
+      editor.setOption("maxLines", elements.maxLines);
       editor.session.setValue(elements.source);
       editor.gotoLine(1, 0, false);
       editor.clearSelection();


### PR DESCRIPTION
Bring back support for the min-lines and max-lines options. Fetch the session name from the data-attribute too, instead of parsing it.