### PR TITLE
chore: release v0.0.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Zensical user interface",
   "bugs": {
     "url": "https://github.com/zensical/ui/issues",


### PR DESCRIPTION
## Summary

This version improves Pyodide-powered code execution and fixes a few issues around rendered code fences. The `min-lines` and `max-lines` options are now correctly recognized, Pyodide output is written more safely, and ANSI color styles are included for `markdown-exec`.

It also fixes a search crash that could occur with specific queries and switches the Pyodide CDN to `unpkg.com`.