### PR TITLE
chore: release v0.0.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Zensical user interface",
   "bugs": {
     "url": "https://github.com/zensical/ui/issues",


### PR DESCRIPTION
## Summary

This version updates the UI dependency stack and refreshes the bundled icon sets. The Lucide update adds 27 new icons, updates several existing icon paths, and includes two new Octicons relation icons.

It also resolves several interaction and performance regressions. Tooltip initialization, visibility observation, and palette switching now avoid unnecessary work on large pages, improving responsiveness in Safari, Chrome, and other browsers. Palette tooltips now switch without overlapping, delayed repositioning, or stale labels in Safari.