### PR TITLE
chore: release v0.0.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "license": "MIT",
       "dependencies": {
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Zensical user interface",
   "bugs": {
     "url": "https://github.com/zensical/ui/issues",


### PR DESCRIPTION
## Summary

This versions fixes bugs with tags and search index when the site is served under a subpath, and adds support for a default documentation version.